### PR TITLE
Added unit testfor hte BoughtProductService. forgot to make them in t…

### DIFF
--- a/TestCore/BoughtProductsServiceTests.cs
+++ b/TestCore/BoughtProductsServiceTests.cs
@@ -1,0 +1,88 @@
+using Grocery.Core.Interfaces.Repositories;
+using Grocery.Core.Models;
+using Grocery.Core.Services;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace TestCore
+{
+    public class BoughtProductsServiceTests
+    {
+        private Mock<IGroceryListItemsRepository> _groceryListItemsRepoMock;
+        private Mock<IGroceryListRepository> _groceryListRepoMock;
+        private Mock<IClientRepository> _clientRepoMock;
+        private Mock<IProductRepository> _productRepoMock;
+        private BoughtProductsService _service;
+
+        [SetUp]
+        public void Setup()
+        {
+            _groceryListItemsRepoMock = new Mock<IGroceryListItemsRepository>();
+            _groceryListRepoMock = new Mock<IGroceryListRepository>();
+            _clientRepoMock = new Mock<IClientRepository>();
+            _productRepoMock = new Mock<IProductRepository>();
+
+            _service = new BoughtProductsService(
+                _groceryListItemsRepoMock.Object,
+                _groceryListRepoMock.Object,
+                _clientRepoMock.Object,
+                _productRepoMock.Object
+            );
+        }
+
+        [Test]
+        public void Get_ReturnsEmptyList_WhenProductIdIsNull()
+        {
+            var result = _service.Get(null);
+            Assert.IsNotNull(result);
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Get_ReturnsEmptyList_WhenNoGroceryListItemsMatch()
+        {
+            _groceryListItemsRepoMock.Setup(r => r.GetAll()).Returns(new List<GroceryListItem>());
+            var result = _service.Get(1);
+            Assert.IsNotNull(result);
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Get_ReturnsBoughtProducts_WhenDataIsValid()
+        {
+            var groceryListItem = new GroceryListItem(1, 2, 3, 1);
+            _groceryListItemsRepoMock.Setup(r => r.GetAll()).Returns(new List<GroceryListItem> { groceryListItem });
+
+            var groceryList = new GroceryList(2, "List", DateOnly.FromDateTime(DateTime.Today), "red", 5);
+            _groceryListRepoMock.Setup(r => r.Get(2)).Returns(groceryList);
+
+            var client = new Client(5, "John", "john@email.com", "pw");
+            _clientRepoMock.Setup(r => r.Get(5)).Returns(client);
+
+            var product = new Product(3, "Milk", 10);
+            _productRepoMock.Setup(r => r.Get(3)).Returns(product);
+
+            var result = _service.Get(3);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Client, Is.EqualTo(client));
+            Assert.That(result[0].GroceryList, Is.EqualTo(groceryList));
+            Assert.That(result[0].Product, Is.EqualTo(product));
+        }
+
+        [Test]
+        public void Get_SkipsItems_WhenAnyDependencyReturnsNull()
+        {
+            var groceryListItem = new GroceryListItem(1, 2, 3, 1);
+            _groceryListItemsRepoMock.Setup(r => r.GetAll()).Returns(new List<GroceryListItem> { groceryListItem });
+
+            // Simulate missing grocery list
+            _groceryListRepoMock.Setup(r => r.Get(2)).Returns((GroceryList)null);
+
+            var result = _service.Get(3);
+            Assert.IsEmpty(result);
+        }
+    }
+}

--- a/TestCore/TestCore.csproj
+++ b/TestCore/TestCore.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />


### PR DESCRIPTION
This pull request introduces a new unit test suite for the `BoughtProductsService` and adds the necessary mocking library dependency to the test project. The tests cover multiple scenarios for the `Get` method, ensuring correct behavior under various conditions.

Testing improvements:

* Added a new test class `BoughtProductsServiceTests` in `TestCore/BoughtProductsServiceTests.cs`, which includes tests for the `Get` method covering cases such as null product IDs, no matching items, valid data retrieval, and handling of missing dependencies.

Dependency updates:

* Added the `Moq` package (version 4.20.72) to `TestCore/TestCore.csproj` to enable mocking of repository interfaces in unit tests.…he feature branche